### PR TITLE
Add co-advisor field and fix mobile overflow

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -107,12 +107,14 @@ current:
   - name: "Shiwon Park"
     name_ko: "박시원"
     role: "Master's Student"
-    department: "AIM"
+    department: "AI4Math"
     image: "/people/images/shiwon_park_sq.jpg"
     linkedin: "https://www.linkedin.com/in/siwonpada/"
     website: "https://siwonpada.github.io/"
     github: "https://github.com/siwonpada"
-    bio: "is a master's student in the AI4Math Department at KAIST. He received a BS degree in Electrical Engineering and Computer Science (EECS) from Gwangju Institute of Science and Technology (GIST). His current research interests include combinatorial optimization, reinforcement learning, and quantum computing. He joined COMET in 2026."
+    co_advisor: "Professor Donghwan Kim"
+    co_advisor_url: "https://mathsci.kaist.ac.kr/~donghwankim/index.html"
+    bio: "is a master's student in the Graduate School of AI for Math at KAIST. He received a BS degree in Electrical Engineering and Computer Science (EECS) from Gwangju Institute of Science and Technology (GIST). His current research interests include combinatorial optimization, reinforcement learning, and quantum computing. His co-advisor is Professor Donghwan Kim. He joined COMET in 2026."
     show_publications: true
 
   - name: "Sangil Han"

--- a/_includes/member-card.html
+++ b/_includes/member-card.html
@@ -30,6 +30,9 @@ Usage: {% include member-card.html member=member %}
     {% if m.primary_advisor %}
     <p class="member-card__advisor">Co-advised by <a href="{{ m.primary_advisor_url }}">{{ m.primary_advisor }}</a></p>
     {% endif %}
+    {% if m.co_advisor %}
+    <p class="member-card__advisor">Co-advised by <a href="{{ m.co_advisor_url }}">{{ m.co_advisor }}</a></p>
+    {% endif %}
     {% if m.show_publications %}
     <div class="member-card__publications">
       <span class="member-publications" data-author="{{ m.name }}"></span>

--- a/css/people.css
+++ b/css/people.css
@@ -417,13 +417,27 @@ h3 + ul li p {
         justify-content: center;
     }
 
+    .member-card__name {
+        font-size: 1.35rem;
+    }
+
     .member-card__role {
         justify-content: center;
     }
 
     .member-card__photo img {
-        width: 120px;
-        height: 120px;
+        width: 80px;
+        height: 80px;
+    }
+
+    .member-card__link {
+        width: 28px;
+        height: 28px;
+    }
+
+    .member-card__link img {
+        width: 16px;
+        height: 16px;
     }
 
     .members-grid {

--- a/css/people.css
+++ b/css/people.css
@@ -21,6 +21,9 @@
    ======================================== */
 
 .member-card {
+    box-sizing: border-box;
+    min-width: 0;
+    overflow-wrap: break-word;
     background: #fafafa;
     border-radius: 12px;
     padding: 1.5rem;

--- a/css/people.css
+++ b/css/people.css
@@ -407,22 +407,11 @@ h3 + ul li p {
 
 @media (max-width: 600px) {
     .member-card {
-        flex-direction: column;
-        align-items: center;
-        text-align: center;
         padding: 1.25rem;
-    }
-
-    .member-card__header {
-        justify-content: center;
     }
 
     .member-card__name {
         font-size: 1.35rem;
-    }
-
-    .member-card__role {
-        justify-content: center;
     }
 
     .member-card__photo img {


### PR DESCRIPTION
## Summary
- Add `co_advisor` / `co_advisor_url` data fields and template rendering for members whose primary advisor is Prof. Kwon but have a co-advisor (applied to Shiwon Park → Professor Donghwan Kim)
- Fix member card overflowing viewport width on iOS mobile by adding `box-sizing: border-box`, `min-width: 0`, and `overflow-wrap: break-word`
- Update Shiwon Park's department from "AIM" to "AI4Math" and bio text

## Test plan
- [ ] Run `bundle exec jekyll serve` and verify Shiwon Park's card shows "Co-advised by Professor Donghwan Kim" with correct link
- [ ] Test people page on mobile viewport (375px) — no horizontal scrollbar should appear
- [ ] Verify desktop layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)