### PR TITLE
Fix abstract toggle for co-authored papers and randomize member order

### DIFF
--- a/lib/member-publications.js
+++ b/lib/member-publications.js
@@ -66,7 +66,7 @@
             mainPubs.forEach(function(pub) { allPublications.push(pub); });
             coadvisePubs.forEach(function(pub) { allPublications.push(pub); });
 
-            containers.forEach(function(container) {
+            containers.forEach(function(container, containerIndex) {
                 var authorName = container.getAttribute('data-author');
                 if (!authorName) return;
 
@@ -103,6 +103,29 @@
                     matchingPubs.forEach(function(pub) {
                         var li = document.createElement('li');
                         li.innerHTML = pub.innerHTML;
+
+                        // Make abstract IDs unique per member card and rebind toggle
+                        var suffix = '_m' + containerIndex;
+                        var absButtons = li.querySelectorAll('.abstract_button');
+                        absButtons.forEach(function(btn) {
+                            var oldId = btn.getAttribute('id');
+                            if (oldId) {
+                                var newParam = oldId + suffix;
+                                btn.setAttribute('id', newParam);
+                                btn.removeAttribute('href');
+                                btn.removeAttribute('onclick');
+                                btn.style.cursor = 'pointer';
+                                btn.addEventListener('click', function(e) {
+                                    e.preventDefault();
+                                    toggle(newParam);
+                                });
+                                var div = li.querySelector('#' + CSS.escape(oldId + 'div'));
+                                if (div) {
+                                    div.setAttribute('id', newParam + 'div');
+                                }
+                            }
+                        });
+
                         list.appendChild(li);
                     });
 

--- a/people/people.md
+++ b/people/people.md
@@ -67,3 +67,18 @@ The Computational Optimization Methods (COMET) Lab is a research group led by Dr
 
 <link rel="stylesheet" href="/css/people.css">
 <script src="/lib/member-publications.js"></script>
+<script>
+(function() {
+  var grid = document.querySelector('.members-grid');
+  if (!grid) return;
+  var cards = Array.from(grid.children);
+  var pi = cards.shift();
+  for (var i = cards.length - 1; i > 0; i--) {
+    var j = Math.floor(Math.random() * (i + 1));
+    var temp = cards[i]; cards[i] = cards[j]; cards[j] = temp;
+  }
+  grid.textContent = '';
+  grid.appendChild(pi);
+  cards.forEach(function(c) { grid.appendChild(c); });
+})();
+</script>


### PR DESCRIPTION
## Summary
- Fix abstract buttons not working in member cards when the same paper appears in multiple students' "Papers" sections (duplicate DOM IDs caused `getElementById` to fail)
- Randomize student card display order on each page load (PI card stays first)

## Details
When a paper is co-authored by multiple students (e.g., Jae Hyeok Lee and Taekang Hwang), cloning the publication HTML into each card created duplicate element IDs. The `toggle()` function uses `getElementById()`, which only returns the first match, so the abstract button on the second card would toggle the wrong element or nothing at all.

The fix appends a unique suffix (`_m0`, `_m1`, ...) to abstract button and div IDs per member card, and uses `addEventListener` instead of `onclick`/`href` attributes for reliable event binding after `innerHTML` cloning.

## Test plan
- [ ] Open people page, find two students who co-author a paper
- [ ] Expand "Papers" on both cards, click "abstract" on each — verify both toggle independently
- [ ] Test abstract for co-advisee papers (e.g., Jaehwan Lee's battery paper)
- [ ] Verify abstracts on the main `/publications/` page still work
- [ ] Refresh the page a few times to confirm student cards shuffle randomly

🤖 Generated with [Claude Code](https://claude.com/claude-code)